### PR TITLE
Add banner image above hero title

### DIFF
--- a/components/HeroSection.js
+++ b/components/HeroSection.js
@@ -15,17 +15,17 @@ export default function HeroSection() {
 
   return (
     <section
-      className="header hero-bg relative pt-16 items-center flex overflow-hidden"
+      className="header hero-bg relative pt-16 items-center flex flex-col overflow-hidden"
       style={{ minHeight: height }}
     >
+      <img
+        src="/img/TOP_banner01.png"
+        alt="Top banner"
+        className="w-full"
+      />
       <div className="container mx-auto flex flex-wrap items-start px-4">
         <div className="w-full md:w-6/12 px-4">
           <div className="pt-32 sm:pt-0 text-left">
-            <img
-              src="/img/TOP_banner01.png"
-              alt="Top banner"
-              className="mb-4 max-w-full"
-            />
             <h2 className="hero-title font-semibold text-4xl text-red-600">
               JAPOX - Premium Japanese Performance
             </h2>

--- a/components/HeroSection.js
+++ b/components/HeroSection.js
@@ -21,7 +21,7 @@ export default function HeroSection() {
       <img
         src="/img/TOP_banner01.png"
         alt="Top banner"
-        className="w-full"
+        className="w-full max-h-60 object-contain"
       />
       <div className="container mx-auto flex flex-wrap items-start px-4">
         <div className="w-full md:w-6/12 px-4">

--- a/components/HeroSection.js
+++ b/components/HeroSection.js
@@ -21,6 +21,11 @@ export default function HeroSection() {
       <div className="container mx-auto flex flex-wrap items-start px-4">
         <div className="w-full md:w-6/12 px-4">
           <div className="pt-32 sm:pt-0 text-left">
+            <img
+              src="/img/TOP_banner01.png"
+              alt="Top banner"
+              className="mb-4 max-w-full"
+            />
             <h2 className="hero-title font-semibold text-4xl text-red-600">
               JAPOX - Premium Japanese Performance
             </h2>


### PR DESCRIPTION
## Summary
- show TOP_banner01 graphic before the hero section title

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881e653fab48329bd9428ce0708c323